### PR TITLE
changed the probe field name so it is not truncated and indistinguish…

### DIFF
--- a/src/main/scala/cogdebugger/ui/Desktop.scala
+++ b/src/main/scala/cogdebugger/ui/Desktop.scala
@@ -134,7 +134,7 @@ class Desktop(moduleHierarchy: ModuleHierarchyTree, probeManager: ProbeManager)
         def addViewer(title: String, viewer: Viewer) =
           this.addViewer(title, viewer, pf)
 
-        val title = pf.simpleName + " " + pf.fieldType
+        val title = pf.name.mkString(".") + " " + pf.fieldType
         pf.fieldType.elementType match {
           case Float32 =>
             (pf.fieldType.dimensions, pf.fieldType.tensorOrder) match {


### PR DESCRIPTION
…able from other probe fields

Cogdebugger Issue

This is to fix the issue I opened. It shows up with the new API for the neural network toolkit. Probe field names in the window title bar get truncated, to "forward" (for example) and it is difficult to know which forward is for which field. 

The proposed change matches the code to name the fields in the Graph (or Fields) panel on the left. 
