### PR TITLE
Cogdebugger probe name change to full name instead of simple name

### DIFF
--- a/src/main/scala/cogdebugger/ui/Desktop.scala
+++ b/src/main/scala/cogdebugger/ui/Desktop.scala
@@ -134,7 +134,7 @@ class Desktop(moduleHierarchy: ModuleHierarchyTree, probeManager: ProbeManager)
         def addViewer(title: String, viewer: Viewer) =
           this.addViewer(title, viewer, pf)
 
-        val title = pf.simpleName + " " + pf.fieldType
+        val title = pf.name.mkString(".") + " " + pf.fieldType
         pf.fieldType.elementType match {
           case Float32 =>
             (pf.fieldType.dimensions, pf.fieldType.tensorOrder) match {

--- a/src/main/scala/cogdebugger/ui/Desktop.scala
+++ b/src/main/scala/cogdebugger/ui/Desktop.scala
@@ -376,7 +376,8 @@ class Desktop(moduleHierarchy: ModuleHierarchyTree, probeManager: ProbeManager)
 
           // Restore the viewer's saved size and position.
           frameTag \ "visualization" \ "properties" foreach (tag => viewer.xmlToProperties(tag))
-          val frame = addViewer(probedField.simpleName+" "+probedField.fieldType, viewer, probedField)
+          //val frame = addViewer(probedField.simpleName+" "+probedField.fieldType, viewer, probedField)
+          val frame = addViewer(probedField.name.mkString(".") +" "+probedField.fieldType, viewer, probedField)
           val (x, y, width, height) = RestorableState.readLayoutTag(frameTag \ "layout" head)
           frame.bounds = (x, y, width, height)
 


### PR DESCRIPTION
Fix for cogdebugger issue:

Problem:
When inspecting a probed field in the cogdebugger, probed field's name used in the title bar of a window on the right panel. The field name is truncated to what is right of the last period. When using the cogdebugger from the neuralnetwork toolkit, more than one probed field can have the same name,  "forward", for example. This makes it difficult to distinguish different probed fields.

Fix: 
The fix is to show the full name of the field, for example "fc1.output.forward" and "fc2.output.forward". The fix was applied in two places for the normal case, and for the case when the cogdebugger restores some state from a previous invocation.
